### PR TITLE
Add get() overload for built-in arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [Bool](#bool)
   - [Random value from std::initilizer_list](#random-value-from-stdinitilizer_list)
   - [Random iterator](#random-iterator)
+  - [Random element from array](#random-element-from-array)
   - [Shuffle](#shuffle)
   - [Custom distribution](#custom-distribution)
   - [Custom Seeder](#custom-seeder)
@@ -169,6 +170,12 @@ auto randomIt = Random::get( array.begin(), array.end() );
 * Container
 ```cpp
 auto randomIt = Random::get( array );
+```
+### Random element from array
+Return pointer to random element in built-in array
+```cpp
+int array [] = {1, 2, 3};
+auto randomPtr = Random::get( array );
 ```
 ### Shuffle
 Reorders the elements in a given range or in all container [ref](http://en.cppreference.com/w/cpp/algorithm/random_shuffle)

--- a/include/effolkronium/random.hpp
+++ b/include/effolkronium/random.hpp
@@ -376,6 +376,16 @@ namespace effolkronium {
             return get( std::begin( container ), std::end( container ) );
         }
 
+		/**
+		* \brief Return random pointer from built-in array
+		* \param array The built-in array with elements
+		* \return Pointer to random element in array
+		*/
+		template<typename T, std::size_t N>
+		static T* get(T(&array)[N]) {
+			return std::addressof(array[get<std::size_t>(0, N - 1)]);
+		}
+
         /**
         * \brief Return value from custom Dist distribution
         *        seeded by internal random engine
@@ -718,6 +728,16 @@ namespace effolkronium {
             return get( std::begin( container ), std::end( container ) );
         }
 
+		/**
+		* \brief Return random pointer from built-in array
+		* \param array The built-in array with elements
+		* \return Pointer to random element in array
+		*/
+		template<typename T, std::size_t N>
+		static T* get(T(&array)[N]) {
+			return std::addressof(array[get<std::size_t>(0, N - 1)]);
+		}
+
         /**
         * \brief Return value from custom Dist distribution
         *        seeded by internal random engine
@@ -1057,6 +1077,16 @@ namespace effolkronium {
         >::type get( Container& container ) {
             return get( std::begin( container ), std::end( container ) );
         }
+
+		/**
+		* \brief Return random pointer from built-in array
+		* \param array The built-in array with elements
+		* \return Pointer to random element in array
+		*/
+		template<typename T, std::size_t N>
+		T* get(T(&array)[N]) {
+			return std::addressof(array[get<std::size_t>(0, N - 1)]);
+		}
 
         /**
         * \brief Return value from custom Dist distribution

--- a/test/random_test.cpp
+++ b/test/random_test.cpp
@@ -683,6 +683,34 @@ TEST_CASE( "return random iterator from container" ) {
     }
 }
 
+TEST_CASE( "return random pointer from built-in array" ) {
+    SECTION( "Matches" ) {
+		int carray [5] = { 1, 2, 3, 4, 5 };
+        std::uintmax_t counter{ std::numeric_limits<std::uintmax_t>::max( ) };
+        bool is1{ false }, is2{ false }, is3{ false },
+            is4{ false }, is5{ false }, isEnd{ false };
+        do {
+            auto ptr = Random DOT get( carray );
+            if( ptr == std::end( carray ) ) {
+                isEnd = true;
+                break;
+            }
+            switch( *ptr ) {
+                case 1: is1 = true; break;
+                case 2: is2 = true; break;
+                case 3: is3 = true; break;
+                case 4: is4 = true; break;
+                case 5: is5 = true; break;
+            }
+        } while( !( is1 && is2 && is3 && is4 && is5 ) && counter--);
+
+        bool isAllMatches = is1 && is2 && is3 && is4 && is5;
+
+        REQUIRE( isAllMatches );
+        REQUIRE( false == isEnd );
+    }
+}
+
 TEST_CASE( "Random range with default arguments" ) {
     Random DOT get<uint8_t>( );
     Random DOT get<uint16_t>( );


### PR DESCRIPTION
Hi,

I added an overload of get() for built-in arrays. I know this isn’t completely necessary as we can already write get(std::begin(carray), std::end(carray) ) though I prefer less verbosity.

I deliberated between returning a pointer or a reference. I decided to return a pointer for consistency with the other overloads; if we passed a built-in array as above it would return an iterator, and the container overload also returns an iterator. 

I’d be grateful for your feedback.

If you like I’d be happy to write tests and update the documentation.

Kind regards,

Riccardo
