### PR TITLE
Make Engine private

### DIFF
--- a/include/effolkronium/random.hpp
+++ b/include/effolkronium/random.hpp
@@ -673,7 +673,7 @@ namespace effolkronium {
         static Engine& engine() {
             return engine_instance();
         }
-    protected:
+    private:
         /// get reference to the static engine instance
         static Engine& engine_instance( ) {
             static Engine engine{ Seeder{ }( ) };
@@ -1191,7 +1191,7 @@ namespace effolkronium {
         static Engine& engine() {
             return engine_instance();
         }
-    protected:
+    private:
         /// get reference to the thread local engine instance
         static Engine& engine_instance( ) {
             thread_local Engine engine{ Seeder{ }( ) };

--- a/include/effolkronium/random.hpp
+++ b/include/effolkronium/random.hpp
@@ -1713,7 +1713,7 @@ namespace effolkronium {
             // Make seeder instance for seed return by reference like std::seed_seq
             return Engine{ Seeder{ }( ) };
         }
-    protected:
+    private:
         /// The random number engine
         Engine m_engine{ make_seeded_engine( ) };
     };

--- a/include/effolkronium/random.hpp
+++ b/include/effolkronium/random.hpp
@@ -1707,7 +1707,7 @@ namespace effolkronium {
         Engine& engine() {
             return m_engine;
         }
-    protected:
+    private:
         /// return engine seeded by Seeder
         static Engine make_seeded_engine( ) {
             // Make seeder instance for seed return by reference like std::seed_seq


### PR DESCRIPTION
Rationale for the change:

Protected member variables are similar to global variables; any derived class can modify them. When protected member variables are used, invariants cannot be enforced. Also, protected member variables are hard to maintain since they can be manipulated through multiple classes in different files.

That’s why protected member variables should be changed to private and manipulated exclusively through public or protected member functions of the base class.

[More context](https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#c133-avoid-protected-data)