### PR TITLE
Fix CMake deprecation warning by updating minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required(VERSION 3.5)
+﻿cmake_minimum_required(VERSION 3.10)
 
 # define the project
 project(effolkronium_random VERSION 1.5.0 LANGUAGES CXX)


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```